### PR TITLE
Feature/baud rate parameter

### DIFF
--- a/anello_interfaces/CMakeLists.txt
+++ b/anello_interfaces/CMakeLists.txt
@@ -28,6 +28,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/APHDG.msg"
   "msg/APODO.msg"
   "msg/APHEALTH.msg"
+  "msg/APCOV.msg"
   DEPENDENCIES std_msgs
 )
 

--- a/anello_interfaces/msg/APCOV.msg
+++ b/anello_interfaces/msg/APCOV.msg
@@ -1,0 +1,22 @@
+float64 mcu_time
+
+float64 cov_lat_lat
+float64 cov_lon_lon
+float64 cov_alt_alt
+float64 cov_lat_lon
+float64 cov_lat_alt
+float64 cov_lon_alt
+
+float64 cov_vn_vn
+float64 cov_ve_ve
+float64 cov_vd_vd
+float64 cov_vn_ve
+float64 cov_vn_vd
+float64 cov_ve_vd
+
+float64 cov_roll_roll
+float64 cov_pitch_pitch
+float64 cov_heading_heading
+float64 cov_roll_pitch
+float64 cov_roll_heading
+float64 cov_pitch_heading

--- a/anello_node/CMakeLists.txt
+++ b/anello_node/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(nmea_msgs REQUIRED)
 find_package(mavros_msgs REQUIRED)
 find_package(anello_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 add_executable(anello_ros_driver_node 
   src/anello_ros_driver/main_anello_ros_driver.cpp 
@@ -34,6 +35,7 @@ add_executable(anello_ros_driver_node
 ament_target_dependencies(anello_ros_driver_node 
   rclcpp 
   anello_interfaces
+  sensor_msgs  
   nmea_msgs 
   mavros_msgs
 )

--- a/anello_node/launch/anello_ros_driver_launch.xml
+++ b/anello_node/launch/anello_ros_driver_launch.xml
@@ -12,6 +12,9 @@
     <arg name="anello_local_config_port" default="2222"/>
     <arg name="anello_local_odometer_port" default="3333"/>
 
+    <!-- Baud rate -->
+    <arg name="baud_rate" default="230400"/>
+
     <!--Launch ANELLO ros driver-->
     <!--Update data and config port values to the ports in your system-->
     <node name="anello_ros_driver" pkg="anello_ros_driver" exec="anello_ros_driver_node" output="screen">
@@ -22,6 +25,7 @@
         <param name="anello_local_data_port" value="$(var anello_local_data_port)"/>
         <param name="anello_local_config_port" value="$(var anello_local_config_port)"/>
         <param name="anello_local_odometer_port" value="$(var anello_local_odometer_port)"/>
+        <param name="baud_rate" value="$(var baud_rate)"/>
     </node>
 
     <!-- NTRIP CLIENT PARAMTERS -->

--- a/anello_node/package.xml
+++ b/anello_node/package.xml
@@ -13,6 +13,7 @@
   <depend>nmea_msgs</depend>
   <depend>mavros_msgs</depend>
   <depend>anello_interfaces</depend>
+  <depend>sensor_msgs</depend>
   <!-- Needs this to for the package to show up -->
   <export>                               
     <build_type>ament_cmake</build_type> 

--- a/anello_node/src/anello_ros_driver/comm/anello_config_port.cpp
+++ b/anello_node/src/anello_ros_driver/comm/anello_config_port.cpp
@@ -33,6 +33,7 @@ anello_config_port::anello_config_port(const interface_config_t *config) : uart_
     this->config.local_data_port = config->local_data_port;
     this->config.local_config_port = config->local_config_port;
     this->config.local_odometer_port = config->local_odometer_port;
+    this->config.baud_rate = config->baud_rate;
 }
 
 anello_config_port::~anello_config_port() {
@@ -92,7 +93,7 @@ void anello_config_port::init_uart()
                 DEBUG_PRINT("config_port: Trying port %s", port_name.c_str());
 #endif
                 this->config.config_port_name = port_name;
-                this->uart_port.init(this->config.config_port_name);
+                this->uart_port.init(this->config.config_port_name, this->config.baud_rate);
                 char buf[100];
 
                 this->uart_port.get_data(buf, 100, 10);
@@ -122,7 +123,7 @@ void anello_config_port::init_uart()
     }
     else
     {
-        this->uart_port.init(this->config.config_port_name);
+        this->uart_port.init(this->config.config_port_name, this->config.baud_rate);
     }
 }
 

--- a/anello_node/src/anello_ros_driver/comm/anello_data_port.cpp
+++ b/anello_node/src/anello_ros_driver/comm/anello_data_port.cpp
@@ -33,6 +33,7 @@ anello_data_port::anello_data_port(const interface_config_t *config) : uart_port
     this->config.local_data_port = config->local_data_port;
     this->config.local_config_port = config->local_config_port;
     this->config.local_odometer_port = config->local_odometer_port;
+    this->config.baud_rate = config->baud_rate;
 
     this->decode_success = false;
     this->port_index = 0;
@@ -85,9 +86,11 @@ void anello_data_port::init()
     {
         this->init_ethernet();
     }
-    else
-    {
+    else if (this->auto_detect) {
         this->init_uart();
+    }
+    {
+        this->uart_port.init(this->config.data_port_name, this->config.baud_rate);
     }
 }
 
@@ -103,7 +106,7 @@ void anello_data_port::init_uart()
     DEBUG_PRINT("Data: Trying port %s", this->uart_port.get_portname().c_str());
 #endif
 
-    this->uart_port.init(this->config.data_port_name);
+    this->uart_port.init(this->config.data_port_name, this->config.baud_rate);
 }
 
 void anello_data_port::init_ethernet()
@@ -156,7 +159,7 @@ void anello_data_port::port_parse_fail_uart()
 
         //reset port
         this->uart_port.close_port();
-        this->uart_port.init(this->config.data_port_name);
+        this->uart_port.init(this->config.data_port_name, this->config.baud_rate);
     }
 }
 

--- a/anello_node/src/anello_ros_driver/comm/base_interface.h
+++ b/anello_node/src/anello_ros_driver/comm/base_interface.h
@@ -30,6 +30,7 @@ typedef struct
 	int local_data_port;
 	int local_config_port;
 	int local_odometer_port;
+    uint32_t baud_rate;
 } interface_config_t;
 
 class base_interface

--- a/anello_node/src/anello_ros_driver/comm/serial_interface.cpp
+++ b/anello_node/src/anello_ros_driver/comm/serial_interface.cpp
@@ -34,10 +34,12 @@ serial_interface::serial_interface()
     this->portname = "";
     this->usb_fd = -1;
     this->port_enabled = false;
+    this->baud_rate_ = 230400;
 }
 
-void serial_interface::init(std::string portname)
+void serial_interface::init(std::string portname, uint32_t baud_rate)
 {
+    this->baud_rate_ = baud_rate;
     this->portname = portname;
 
 
@@ -77,8 +79,18 @@ void serial_interface::init(std::string portname)
     options.c_cc[VMIN] = 0;      // read doesn't block
     options.c_cc[VTIME] = 5;     // 0.5 seconds read timeout
 
-    cfsetispeed(&options, BAUDRATE);
-    cfsetospeed(&options, BAUDRATE);
+    speed_t speed;
+    switch(this->baud_rate_) {
+      case 230400:   speed = B230400;   break;
+      case 921600:   speed = B921600;   break; 
+      default:
+        RCLCPP_WARN(rclcpp::get_logger("serial_interface"),
+                    "Unsupported baud %d, falling back to 230400", this->baud_rate_);
+        speed = B230400;
+    }
+    cfsetispeed(&options, speed);
+    cfsetospeed(&options, speed);
+
     
     // set the options
     if (tcsetattr(this->usb_fd, TCSANOW, &options) != 0)

--- a/anello_node/src/anello_ros_driver/comm/serial_interface.h
+++ b/anello_node/src/anello_ros_driver/comm/serial_interface.h
@@ -41,8 +41,8 @@
 #endif
 
 #ifndef BAUDRATE
-#define BAUDRATE B230400    //Default baudrate for ANELLO GNSS INS and IMU+
-// #define BAUDRATE B921600    //Default baudrate for ANELLO EVK
+//#define BAUDRATE B230400    //Default baudrate for ANELLO GNSS INS and IMU+
+#define BAUDRATE B921600    //Default baudrate for ANELLO EVK
 #endif
 
 #ifndef MAX_PORT_PARSE_FAIL

--- a/anello_node/src/anello_ros_driver/comm/serial_interface.h
+++ b/anello_node/src/anello_ros_driver/comm/serial_interface.h
@@ -40,11 +40,6 @@
 #define PORT_PREFIX "ttyUSB"
 #endif
 
-#ifndef BAUDRATE
-//#define BAUDRATE B230400    //Default baudrate for ANELLO GNSS INS and IMU+
-#define BAUDRATE B921600    //Default baudrate for ANELLO EVK
-#endif
-
 #ifndef MAX_PORT_PARSE_FAIL
 #define MAX_PORT_PARSE_FAIL 5
 #endif
@@ -55,6 +50,7 @@ protected:
     bool port_enabled;
     int usb_fd;
     std::string portname;
+    uint32_t baud_rate_;
 
 public:
 
@@ -71,7 +67,7 @@ public:
      * Notes:
      * This function initializes the serial port interface including configuring the port.
      */
-    void init(std::string portname);
+    void init(std::string portname, uint32_t baud_rate);
 
     /*
      * Parameters:

--- a/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
+++ b/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
@@ -34,6 +34,7 @@
 #include "anello_interfaces/msg/apgps.hpp"
 #include "anello_interfaces/msg/aphdg.hpp"
 #include "anello_interfaces/msg/aphealth.hpp"
+#include "anello_interfaces/msg/apcov.hpp"
 
 #include "sensor_msgs/msg/imu.hpp"
 
@@ -140,6 +141,39 @@ struct Vec3
 	double z{0.0};
 };
 
+struct Vec6
+{
+	double xx{0.0};
+	double xy{0.0};
+	double xz{0.0};
+	double yx{0.0};
+	double yy{0.0};
+	double yz{0.0};
+	double zx{0.0};
+	double zy{0.0};
+	double zz{0.0};
+};
+
+struct posCovVec
+{
+	double latlat{0.0};
+	double latlon{0.0};
+	double latalt{0.0};
+	double lonlat{0.0};
+	double lonlon{0.0};
+	double lonalt{0.0};
+	double altlat{0.0};
+	double altlon{0.0};
+	double altalt{0.0};
+};
+
+const double PI = 3.14159265;
+double d2r = PI/180.0;
+double s = d2r*d2r;
+
+const double GYRO_VARIANCE  = 0.00;   // (rad/s)^2
+const double ACCEL_VARIANCE = 0.00;   // (m/s^2)^2
+
 typedef struct
 {
 	int n_used;				// how many bytes have been put through the decoded
@@ -223,9 +257,10 @@ public:
 		_hdg_publisher = this->create_publisher<anello_interfaces::msg::APHDG>("APHDG", 10);
 		_health_publisher = this->create_publisher<anello_interfaces::msg::APHEALTH>("APHEALTH", 1);
 		_gga_publisher = this->create_publisher<nmea_msgs::msg::Sentence>("ntrip_client/nmea", 1);
-		
-		_ros_imu_pub = this->create_publisher<sensor_msgs::msg::Imu>("ROS_IMU", 10);
-	    _navfix_publisher = this->create_publisher<sensor_msgs::msg::NavSatFix>("ROS_NAVSATFIX", 10);
+		_apcov_publisher = this->create_publisher<anello_interfaces::msg::APCOV>("APCOV", 10);
+
+		_ros_imu_pub = this->create_publisher<sensor_msgs::msg::Imu>("AP_ROS_IMU", 10);
+	    _navfix_publisher = this->create_publisher<sensor_msgs::msg::NavSatFix>("AP_ROS_NAVSATFIX", 10);
 
 		// create a ntrip rtcm subscriber
 		_rtcm_subscriber = this->create_subscription<mavros_msgs::msg::RTCM>(
@@ -297,6 +332,10 @@ private:
 						RCLCPP_WARN(this->get_logger(), "Checksum Fail: %s", a1buff.buf);
 						num = 0;
 					}
+					
+					RCLCPP_DEBUG(this->get_logger(),
+    					"Packet tag=\"%s\", numFields=%d",
+    					val[0], num);
 
 					if (!isOK && num >= 17 && strstr(val[0], "APGPS") != NULL)
 					{
@@ -360,6 +399,40 @@ private:
 #endif
 						isOK = 1;
 					}
+					else if (!isOK && num >= 17 && strstr(val[0], "APCOV") != NULL)
+					{
+						// ascii cov
+						decode_ascii_cov(val, decoded_val);
+						publish_cov(decoded_val, _apcov_publisher);
+
+						//store orientation covariance vals
+						last_orientation_cov_.xx = decoded_val[13];
+						last_orientation_cov_.xy = decoded_val[17];
+						last_orientation_cov_.xz = decoded_val[18];
+						last_orientation_cov_.yx = decoded_val[17];
+						last_orientation_cov_.yy = decoded_val[14];
+						last_orientation_cov_.yz = decoded_val[19];
+						last_orientation_cov_.zx = decoded_val[18];
+						last_orientation_cov_.zy = decoded_val[19];
+						last_orientation_cov_.zz = decoded_val[15];
+
+						//store position covariance vals
+						last_position_cov_.latlat = decoded_val[1];
+						last_position_cov_.latlon = decoded_val[4];
+						last_position_cov_.latalt = decoded_val[5];
+						last_position_cov_.lonlat = decoded_val[4];
+						last_position_cov_.lonlon = decoded_val[2];
+						last_position_cov_.lonalt = decoded_val[6];
+						last_position_cov_.altlat = decoded_val[5];
+						last_position_cov_.altlon = decoded_val[6];
+						last_position_cov_.altalt = decoded_val[3];
+
+
+#if DEBUG_MAIN
+						printf("APCOVa\n");
+#endif
+						isOK = 1;
+					}
 					else if (!isOK && num >= 14 && strstr(val[0], "APINS") != NULL)
 					{
 						// ascii ins and publish standard ROS Imu msg form
@@ -371,12 +444,10 @@ private:
 						auto ros_imu_msg = sensor_msgs::msg::Imu();
 						auto nav_msg = sensor_msgs::msg::NavSatFix();
 
-						//Conversions
-						const double PI = 3.14159265;
-
-						double roll_rad = decoded_val[9] * PI/180.0;
-						double pitch_rad = decoded_val[10] * PI/180.0;
-						double heading_rad = decoded_val[11] * PI/180.0;
+						//Conversion
+						double roll_rad = decoded_val[9] * d2r;
+						double pitch_rad = decoded_val[10] * d2r;
+						double heading_rad = decoded_val[11] * d2r;
 
 						double cy = cos(heading_rad * 0.5);
 						double sy = sin(heading_rad * 0.5);
@@ -403,32 +474,71 @@ private:
 						ros_imu_msg.orientation.w = cr*cp*cy + sr*sp*sy;
 
 						//Angular velocity (Imu msg)
-						ros_imu_msg.angular_velocity.x = last_angular_vel_.x;
-						ros_imu_msg.angular_velocity.y = last_angular_vel_.y;
-						ros_imu_msg.angular_velocity.z = last_angular_vel_.z;
+						ros_imu_msg.angular_velocity.x = last_angular_vel_.x * d2r;
+						ros_imu_msg.angular_velocity.y = last_angular_vel_.y * d2r;
+						ros_imu_msg.angular_velocity.z = last_angular_vel_.z * d2r;
 
 						//Linear acceleration (Imu msg)
 						ros_imu_msg.linear_acceleration.x = last_linear_accel_.x;
 						ros_imu_msg.linear_acceleration.y = last_linear_accel_.y;
 						ros_imu_msg.linear_acceleration.z = last_linear_accel_.z;
 						
-						//Covariance matrices (Imu msg)
-						for (size_t i = 0; i < 9; ++i) {
-							ros_imu_msg.orientation_covariance[i] = 0;
-							ros_imu_msg.angular_velocity_covariance[i] = 0;
-							ros_imu_msg.linear_acceleration_covariance[i] = 0;
-						}
+						//Orientation covariance matrix (Imu msg)
+						ros_imu_msg.orientation_covariance[0] = last_orientation_cov_.xx * s;
+						ros_imu_msg.orientation_covariance[1] = last_orientation_cov_.xy * s;
+						ros_imu_msg.orientation_covariance[2] = last_orientation_cov_.xz * s;
+						ros_imu_msg.orientation_covariance[3] = last_orientation_cov_.yx * s;
+						ros_imu_msg.orientation_covariance[4] = last_orientation_cov_.yy * s;
+						ros_imu_msg.orientation_covariance[5] = last_orientation_cov_.yz * s;
+						ros_imu_msg.orientation_covariance[6] = last_orientation_cov_.zx * s;
+						ros_imu_msg.orientation_covariance[7] = last_orientation_cov_.zy * s;
+						ros_imu_msg.orientation_covariance[8] = last_orientation_cov_.zz * s;
+
+						//Position covariance matrix (NavSatFix)					
+						nav_msg.position_covariance[0] = last_position_cov_.lonlon;   // C_ee
+						nav_msg.position_covariance[1] = last_position_cov_.latlon;    // C_en
+						nav_msg.position_covariance[2] = last_position_cov_.lonalt;   // C_eu
+
+						nav_msg.position_covariance[3] = last_position_cov_.latlon;   // C_ne
+						nav_msg.position_covariance[4] = last_position_cov_.latlat;  // C_nn
+						nav_msg.position_covariance[5] = last_position_cov_.latalt;    // C_nu
+
+						nav_msg.position_covariance[6] = last_position_cov_.lonalt;     // C_ue
+						nav_msg.position_covariance[7] = last_position_cov_.latalt;    // C_un
+						nav_msg.position_covariance[8] = last_position_cov_.altalt;     // C_uu
+
+						nav_msg.position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_KNOWN;
 
 						//Lat, Long, Alt (NavSatFix)
 						nav_msg.latitude = decoded_val[3];
 						nav_msg.longitude = decoded_val[4];
 						nav_msg.altitude = decoded_val[5];
+						
+						//Angular velocity and linear acceleration covariances
+						ros_imu_msg.angular_velocity_covariance[0] = GYRO_VARIANCE;  
+						ros_imu_msg.angular_velocity_covariance[1] = 0.0;
+						ros_imu_msg.angular_velocity_covariance[2] = 0.0;
 
-						//Covariance matrice (NavSatFix)
-						for (size_t i = 0; i < 9; ++i) {
-							nav_msg.position_covariance[i] = 0;
-						}
-						nav_msg.position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+						ros_imu_msg.angular_velocity_covariance[3] = 0.0;
+						ros_imu_msg.angular_velocity_covariance[4] = GYRO_VARIANCE;  
+						ros_imu_msg.angular_velocity_covariance[5] = 0.0;
+
+						ros_imu_msg.angular_velocity_covariance[6] = 0.0;
+						ros_imu_msg.angular_velocity_covariance[7] = 0.0;
+						ros_imu_msg.angular_velocity_covariance[8] = GYRO_VARIANCE;  
+
+
+						ros_imu_msg.linear_acceleration_covariance[0] = ACCEL_VARIANCE;  
+						ros_imu_msg.linear_acceleration_covariance[1] = 0.0;
+						ros_imu_msg.linear_acceleration_covariance[2] = 0.0;
+
+						ros_imu_msg.linear_acceleration_covariance[3] = 0.0;
+						ros_imu_msg.linear_acceleration_covariance[4] = ACCEL_VARIANCE;  
+						ros_imu_msg.linear_acceleration_covariance[5] = 0.0;
+
+						ros_imu_msg.linear_acceleration_covariance[6] = 0.0;
+						ros_imu_msg.linear_acceleration_covariance[7] = 0.0;
+						ros_imu_msg.linear_acceleration_covariance[8] = ACCEL_VARIANCE;  
 
 						//Publish both messages
 						_ros_imu_pub->publish(ros_imu_msg);
@@ -570,6 +680,7 @@ private:
 	hdg_pub_t _hdg_publisher;
 	health_pub_t _health_publisher;
 	gga_pub_t _gga_publisher;
+	apcov_pub_t _apcov_publisher;
 
 	ros_imu_pub_t _ros_imu_pub;
 	navfix_pub_t _navfix_publisher;
@@ -598,6 +709,10 @@ private:
 	Vec3 last_linear_accel_;
 
 	Vec3 last_angular_vel_;
+
+	Vec6 last_orientation_cov_;
+
+	posCovVec last_position_cov_;
 	
 
 	size_t count;

--- a/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
+++ b/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
@@ -35,6 +35,8 @@
 #include "anello_interfaces/msg/aphdg.hpp"
 #include "anello_interfaces/msg/aphealth.hpp"
 
+#include "sensor_msgs/msg/imu.hpp"
+
 #include "anello_interfaces/msg/apodo.hpp"
 #include "nmea_msgs/msg/sentence.hpp"
 #include "mavros_msgs/msg/rtcm.hpp"
@@ -131,6 +133,13 @@ void sigint_handler(int sig)
 
 using namespace std;
 
+struct Vec3
+{
+	double x{0.0};
+	double y{0.0};
+	double z{0.0};
+};
+
 typedef struct
 {
 	int n_used;				// how many bytes have been put through the decoded
@@ -214,6 +223,9 @@ public:
 		_hdg_publisher = this->create_publisher<anello_interfaces::msg::APHDG>("APHDG", 10);
 		_health_publisher = this->create_publisher<anello_interfaces::msg::APHEALTH>("APHEALTH", 1);
 		_gga_publisher = this->create_publisher<nmea_msgs::msg::Sentence>("ntrip_client/nmea", 1);
+		
+		_ros_imu_pub = this->create_publisher<sensor_msgs::msg::Imu>("ROS_IMU", 10);
+	    _navfix_publisher = this->create_publisher<sensor_msgs::msg::NavSatFix>("ROS_NAVSATFIX", 10);
 
 		// create a ntrip rtcm subscriber
 		_rtcm_subscriber = this->create_subscription<mavros_msgs::msg::RTCM>(
@@ -251,6 +263,8 @@ private:
 		bool checksum_passed = 0;
 		char *val[MAXFIELD];
 		double decoded_val[MAXFIELD];
+		double imu_vals[MAXFIELD];
+		double ins_vals[MAXFIELD];
 
 
 		if (serial_read_buffer.n_used >= serial_read_buffer.nbytes)
@@ -323,6 +337,14 @@ private:
 						decode_ascii_imu(val, num, decoded_val);
 						publish_imu(decoded_val, _imu_publisher);
 						_health_msg.add_imu_message(decoded_val);
+						
+						//store vals for standard ROS Imu msg 
+						last_linear_accel_.x = decoded_val[1];
+						last_linear_accel_.y = decoded_val[2];
+						last_linear_accel_.z = decoded_val[3];
+						last_angular_vel_.x = decoded_val[4];
+						last_angular_vel_.y = decoded_val[5];
+						last_angular_vel_.z = decoded_val[6];
 #if DEBUG_MAIN
 						printf("APIMUa\n");
 #endif
@@ -340,10 +362,78 @@ private:
 					}
 					else if (!isOK && num >= 14 && strstr(val[0], "APINS") != NULL)
 					{
-						// ascii ins
+						// ascii ins and publish standard ROS Imu msg form
 						decode_ascii_ins(val, decoded_val);
 						publish_ins(decoded_val, _ins_publisher);
 						_health_msg.add_ins_message(decoded_val);
+						
+						//define ROS standard Imu msg and NavSatFix msg
+						auto ros_imu_msg = sensor_msgs::msg::Imu();
+						auto nav_msg = sensor_msgs::msg::NavSatFix();
+
+						//Conversions
+						const double PI = 3.14159265;
+
+						double roll_rad = decoded_val[9] * PI/180.0;
+						double pitch_rad = decoded_val[10] * PI/180.0;
+						double heading_rad = decoded_val[11] * PI/180.0;
+
+						double cy = cos(heading_rad * 0.5);
+						double sy = sin(heading_rad * 0.5);
+						double cp = cos(pitch_rad * 0.5);
+						double sp = sin(pitch_rad * 0.5);
+						double cr = cos(roll_rad * 0.5);
+						double sr = sin(roll_rad * 0.5);
+
+						//Stamp and frame
+						ros_imu_msg.header.stamp = this->now();
+						ros_imu_msg.header.frame_id = "anello_link";
+
+						nav_msg.header.stamp = this->now();
+						nav_msg.header.frame_id = "ins_link";
+
+						//Satellite Fix Status (NavSatFix)
+						nav_msg.status.status = sensor_msgs::msg::NavSatStatus::STATUS_FIX;
+						nav_msg.status.service = sensor_msgs::msg::NavSatStatus::SERVICE_GPS;
+
+						//Quaternion orientation (Imu msg)
+						ros_imu_msg.orientation.x = sr*cp*cy - cr*sp*sy;
+						ros_imu_msg.orientation.y = cr*sp*cy + sr*cp*sy;
+						ros_imu_msg.orientation.z = cr*cp*sy - sr*sp*cy;
+						ros_imu_msg.orientation.w = cr*cp*cy + sr*sp*sy;
+
+						//Angular velocity (Imu msg)
+						ros_imu_msg.angular_velocity.x = last_angular_vel_.x;
+						ros_imu_msg.angular_velocity.y = last_angular_vel_.y;
+						ros_imu_msg.angular_velocity.z = last_angular_vel_.z;
+
+						//Linear acceleration (Imu msg)
+						ros_imu_msg.linear_acceleration.x = last_linear_accel_.x;
+						ros_imu_msg.linear_acceleration.y = last_linear_accel_.y;
+						ros_imu_msg.linear_acceleration.z = last_linear_accel_.z;
+						
+						//Covariance matrices (Imu msg)
+						for (size_t i = 0; i < 9; ++i) {
+							ros_imu_msg.orientation_covariance[i] = 0;
+							ros_imu_msg.angular_velocity_covariance[i] = 0;
+							ros_imu_msg.linear_acceleration_covariance[i] = 0;
+						}
+
+						//Lat, Long, Alt (NavSatFix)
+						nav_msg.latitude = decoded_val[3];
+						nav_msg.longitude = decoded_val[4];
+						nav_msg.altitude = decoded_val[5];
+
+						//Covariance matrice (NavSatFix)
+						for (size_t i = 0; i < 9; ++i) {
+							nav_msg.position_covariance[i] = 0;
+						}
+						nav_msg.position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+
+						//Publish both messages
+						_ros_imu_pub->publish(ros_imu_msg);
+						_navfix_publisher->publish(nav_msg);
+
 #if DEBUG_MAIN
 						printf("APINSa\n");
 #endif
@@ -481,6 +571,9 @@ private:
 	health_pub_t _health_publisher;
 	gga_pub_t _gga_publisher;
 
+	ros_imu_pub_t _ros_imu_pub;
+	navfix_pub_t _navfix_publisher;
+
 	rclcpp::Subscription<mavros_msgs::msg::RTCM>::SharedPtr _rtcm_subscriber;
 	rclcpp::Subscription<anello_interfaces::msg::APODO>::SharedPtr _odo_subscriber;
 
@@ -501,6 +594,11 @@ private:
 	a1buff_t a1buff;
 
 	health_message _health_msg;
+
+	Vec3 last_linear_accel_;
+
+	Vec3 last_angular_vel_;
+	
 
 	size_t count;
 };

--- a/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
+++ b/anello_node/src/anello_ros_driver/main_anello_ros_driver.cpp
@@ -71,6 +71,10 @@
 #define CONFIG_PORT_NAME "anello_uart_config_port"
 #endif
 
+#ifndef BAUDRATE_NAME
+#define BAUDRATE_NAME "baud_rate"
+#endif
+
 #ifndef REMOTE_IP_NAME
 #define REMOTE_IP_NAME "anello_remote_ip"
 #endif
@@ -99,6 +103,10 @@
 #define CONFIG_PORT_PARAMETER_NAME CONFIG_PORT_NAME
 #endif
 
+#ifndef BAUDRATE_PARAMETER_NAME
+#define BAUDRATE_PARAMETER_NAME BAUDRATE_NAME
+#endif
+
 #ifndef REMOTE_IP_PARAMETER_NAME
 #define REMOTE_IP_PARAMETER_NAME REMOTE_IP_NAME
 #endif
@@ -121,6 +129,14 @@
 
 #ifndef LOG_FILE_NAME
 #define LOG_FILE_NAME "latest_anello_log.txt"
+#endif
+
+#ifndef GYRO_VARIANCE
+#define GYRO_VARIANCE 0.0   // (rad/s)^2
+#endif
+
+#ifndef ACCEL_VARIANCE
+#define ACCEL_VARIANCE 0.0   // (m/s^2)^2
 #endif
 
 #if !(COMPILE_WITH_ROS2)
@@ -171,9 +187,6 @@ const double PI = 3.14159265;
 double d2r = PI/180.0;
 double s = d2r*d2r;
 
-const double GYRO_VARIANCE  = 0.00;   // (rad/s)^2
-const double ACCEL_VARIANCE = 0.00;   // (m/s^2)^2
-
 typedef struct
 {
 	int n_used;				// how many bytes have been put through the decoded
@@ -200,7 +213,8 @@ public:
 		this->declare_parameter(REMOTE_IP_PARAMETER_NAME, "192.168.1.111");
 		this->declare_parameter(LOCAL_DATA_PORT_PARAMETER_NAME, 1111);
 		this->declare_parameter(LOCAL_CONFIG_PORT_PARAMETER_NAME, 2222);
-		this->declare_parameter(LOCAL_ODOMETER_PORT_PARAMETER_NAME, 3333);
+		this->declare_parameter(LOCAL_ODOMETER_PORT_PARAMETER_NAME, 3333);		
+		this->declare_parameter(BAUDRATE_PARAMETER_NAME, 230400);
 
 		std::string com_type;
 		this->get_parameter(COM_TYPE_PARAMETER_NAME, com_type);
@@ -209,7 +223,11 @@ public:
 		this->get_parameter(REMOTE_IP_PARAMETER_NAME, config.remote_ip);
 		this->get_parameter(LOCAL_DATA_PORT_PARAMETER_NAME, config.local_data_port);
 		this->get_parameter(LOCAL_CONFIG_PORT_PARAMETER_NAME, config.local_config_port);
-		this->get_parameter(LOCAL_ODOMETER_PORT_PARAMETER_NAME, config.local_odometer_port);
+		this->get_parameter(LOCAL_ODOMETER_PORT_PARAMETER_NAME, config.local_odometer_port);		
+		this->get_parameter(BAUDRATE_PARAMETER_NAME, config.baud_rate);
+
+		RCLCPP_INFO(this->get_logger(), "Using baud_rate=%u", config.baud_rate);
+		
 
 		if (com_type == "UART")
 		{
@@ -699,7 +717,7 @@ private:
 	port_buffer config_port_write_buffer;
 
 	interface_config_t config;
-	
+
 	file_read_buf_t serial_read_buffer;
 	
 	a1buff_t a1buff;

--- a/anello_node/src/anello_ros_driver/main_anello_ros_driver.h
+++ b/anello_node/src/anello_ros_driver/main_anello_ros_driver.h
@@ -33,6 +33,8 @@
 #include "anello_interfaces/msg/aphdg.hpp"
 #include "anello_interfaces/msg/aphealth.hpp"
 #include "nmea_msgs/msg/sentence.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+#include "sensor_msgs/msg/nav_sat_fix.hpp"
 #endif
 
 #include "bit_tools.h"
@@ -105,6 +107,9 @@ typedef rclcpp::Publisher<anello_interfaces::msg::APGPS>::SharedPtr gps_pub_t;
 typedef rclcpp::Publisher<anello_interfaces::msg::APHDG>::SharedPtr hdg_pub_t;
 typedef rclcpp::Publisher<anello_interfaces::msg::APHEALTH>::SharedPtr health_pub_t;
 typedef rclcpp::Publisher<nmea_msgs::msg::Sentence>::SharedPtr gga_pub_t;
+
+typedef rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr ros_imu_pub_t;
+typedef rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navfix_pub_t;
 
 typedef struct
 {

--- a/anello_node/src/anello_ros_driver/main_anello_ros_driver.h
+++ b/anello_node/src/anello_ros_driver/main_anello_ros_driver.h
@@ -32,6 +32,7 @@
 #include "anello_interfaces/msg/apgps.hpp"
 #include "anello_interfaces/msg/aphdg.hpp"
 #include "anello_interfaces/msg/aphealth.hpp"
+#include "anello_interfaces/msg/apcov.hpp"
 #include "nmea_msgs/msg/sentence.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
@@ -107,6 +108,7 @@ typedef rclcpp::Publisher<anello_interfaces::msg::APGPS>::SharedPtr gps_pub_t;
 typedef rclcpp::Publisher<anello_interfaces::msg::APHDG>::SharedPtr hdg_pub_t;
 typedef rclcpp::Publisher<anello_interfaces::msg::APHEALTH>::SharedPtr health_pub_t;
 typedef rclcpp::Publisher<nmea_msgs::msg::Sentence>::SharedPtr gga_pub_t;
+typedef rclcpp::Publisher<anello_interfaces::msg::APCOV>::SharedPtr apcov_pub_t;
 
 typedef rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr ros_imu_pub_t;
 typedef rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navfix_pub_t;

--- a/anello_node/src/anello_ros_driver/messaging/ascii_decoder.cpp
+++ b/anello_node/src/anello_ros_driver/messaging/ascii_decoder.cpp
@@ -144,3 +144,27 @@ int decode_ascii_ins(char *val[], double *output_val)
 
     return 1;
 }
+
+int decode_ascii_cov(char *val[], double *output_val)
+{
+    output_val[0] = atof(val[1]); /* time MCU */
+    output_val[1] = atof(val[2]); /* covLatLat */
+    output_val[2] = atof(val[3]); /* covLonLon */
+    output_val[3] = atof(val[4]); /* covAltAlt */
+    output_val[4] = atof(val[5]); /* covLatLon */
+    output_val[5] = atof(val[6]); /* covLatAlt */
+    output_val[6] = atof(val[7]); /* covLonAlt */
+    output_val[7] = atof(val[8]); /* covVnVn */
+    output_val[8] = atof(val[9]); /* covVeVe */
+    output_val[9] = atof(val[10]); /* covVdVd */
+    output_val[10] = atof(val[11]); /* covVnVe */
+    output_val[11] = atof(val[12]); /* covVnVd */
+    output_val[12] = atof(val[13]); /* covVeVd */
+    output_val[13] = atof(val[14]); /* covRollRoll */
+    output_val[14] = atof(val[15]); /* covPitchPitch */
+    output_val[15] = atof(val[16]); /* covYawYaw */
+    output_val[16] = atof(val[17]); /* covRollPitch */
+    output_val[17] = atof(val[18]); /* covRollYaw */
+    output_val[18] = atof(val[19]); /* covPitchYaw */
+    return 1;
+}

--- a/anello_node/src/anello_ros_driver/messaging/ascii_decoder.h
+++ b/anello_node/src/anello_ros_driver/messaging/ascii_decoder.h
@@ -67,4 +67,14 @@ int decode_ascii_im1(char *val[], int field_num, double *output_val);
  */
 int decode_ascii_ins(char *val[], double *output_val);
 
+/*
+ * Parameters:
+ * char *val[] : array of char arrays will be decoded and published
+ * double *val : pointer to an array of the same size of val which is filled with the decoded values of val
+ *
+ * Return:
+ * 1 if the decode succeeded
+ */
+int decode_ascii_cov(char *val[], double *output_val);
+
 #endif

--- a/anello_node/src/anello_ros_driver/messaging/message_publisher.cpp
+++ b/anello_node/src/anello_ros_driver/messaging/message_publisher.cpp
@@ -28,6 +28,7 @@
 #include "anello_interfaces/msg/apgps.hpp"
 #include "anello_interfaces/msg/aphdg.hpp"
 #include "anello_interfaces/msg/aphealth.hpp"
+#include "anello_interfaces/msg/apcov.hpp"
 
 #include <nmea_msgs/msg/sentence.hpp>
 #include <mavros_msgs/msg/rtcm.hpp>
@@ -464,6 +465,55 @@ void publish_ins(double *ins, ins_pub_t pub)
 #if DEBUG_PUBLISHERS
 	DEBUG_PRINT("APINS,%10.3f,%14.7f,%10.4f,%14.9f,%14.9f,%10.4f,%10.4f,%10.4f,%10.4f,%10.4f,%10.4f,%10.4f,%10.4f\n", ins[0], ins[1], ins[2], ins[3], ins[4], ins[5], ins[6], ins[7], ins[8], ins[9], ins[10], ins[11], ins[12]);
 #endif
+}
+
+void publish_cov(double *cov, apcov_pub_t pub)
+{
+	/*
+	 * cov[0] = MCU_Time [ms]
+	 * cov[1] = covLatLat [m^2]
+	 * cov[2] = covLonLon [m^2]
+	 * cov[3] = covAltAlt [m^2]
+	 * cov[4] = covLatLon [m^2]
+	 * cov[5] = covLatAlt [m^2]
+	 * cov[6] = covLonAlt [m^2]
+	 * cov[7] = covVnVn [m^2/s^2]
+	 * cov[8] = covVeVe [m^2/s^2]
+	 * cov[9] = covVdVd [m^2/s^2]
+	 * cov[10] = covVnVe [m^2/s^2]
+	 * cov[11] = covVnVd [m^2/s^2]
+	 * cov[12] = covVeVd [m^2/s^2]
+	 * cov[13] = covRollRoll [deg^2]
+	 * cov[14] = covPitchPitch [deg^2]
+	 * cov[15] = covYawYaw [deg^2]
+	 * cov[16] = covRollPitch [deg^2]
+	 * cov[17] = covRollYaw [deg^2]
+	 * cov[18] = covPitchYaw [deg^2]
+	 */
+
+	anello_interfaces::msg::APCOV msg;
+
+	msg.mcu_time = (uint64_t)cov[0];
+	msg.cov_lat_lat = (float)cov[1];
+	msg.cov_lon_lon = (float)cov[2];
+	msg.cov_alt_alt = (float)cov[3];
+	msg.cov_lat_lon = (float)cov[4];
+	msg.cov_lat_alt = (float)cov[5];
+	msg.cov_lon_alt = (float)cov[6];
+	msg.cov_vn_vn = (float)cov[7];
+	msg.cov_ve_ve = (float)cov[8];
+	msg.cov_vd_vd = (float)cov[9];
+	msg.cov_vn_ve = (float)cov[10];
+	msg.cov_vn_vd = (float)cov[11];
+	msg.cov_ve_vd = (float)cov[12];
+	msg.cov_roll_roll = (float)cov[13];
+	msg.cov_pitch_pitch = (float)cov[14];
+	msg.cov_heading_heading = (float)cov[15];
+	msg.cov_roll_pitch = (float)cov[16];
+	msg.cov_roll_heading = (float)cov[17];
+	msg.cov_pitch_heading = (float)cov[18];
+
+	pub->publish(msg);
 }
 
 void publish_health(const health_message *health_msg, health_pub_t pub)

--- a/anello_node/src/anello_ros_driver/messaging/message_publisher.h
+++ b/anello_node/src/anello_ros_driver/messaging/message_publisher.h
@@ -103,6 +103,17 @@ void publish_gga(double *gps, gga_pub_t pub, rclcpp::Time time);
  * The publisher is called here
  */
 void publish_health(const health_message *health_msg, health_pub_t pub);
+
+/*
+ * Parameters:
+ * double *gps : Double array at least 18 items long that contains the cov msg fields
+ * apcov_pub_t pub : Publisher used to publish the cov message
+ *
+ * Notes:
+ * The publisher is called here
+ */
+void publish_cov(double *cov, apcov_pub_t pub);
+
 #endif
 
 #endif


### PR DESCRIPTION
### Feature: Baud rate as a parameter

- Implemented baud rate as a parameter to replace the original #define

### Validation:

- Set the baud rate to different values to verify expected results (incorrect = can't connect, random baud = can't connect + message stating unknown baud, correct = connects normally)

### Notes:
- It uses case and switch logic between the baud rates of the EVK and GNSS/INS (921,600 and 230,400). Any baudrate besides that will yield a message stating unknown baudrate